### PR TITLE
Bugfix for FuzzyGInterface class not returning valid locations

### DIFF
--- a/geocode/query_funcs.py
+++ b/geocode/query_funcs.py
@@ -493,7 +493,7 @@ class FuzzyGInterface(WebInterface):
                 self.location_results.append(
                     GeocodedLocation(
                         points_list = [
-                            [loc_dict['ddlong'], loc_dict['ddlat']]
+                            [float(loc_dict['ddlong']), float(loc_dict['ddlat'])]
                         ],
                         address_name = loc_dict['fullname'],
                         location_type = loc_dict['dsg']['#text'],


### PR DESCRIPTION
The library we use to parse XML automatically reads in all objects as strings, so I just had to convert the latitude and longitude to floats when creating a GeocodedLocation object from these results.