### PR TITLE
Python upgrade to 3.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+KUBECMD := ~/kubectl
+
+start-basic:
+	$(KUBECMD) apply -f batchgeocode.yaml
+    
+stop-basic:
+	$(KUBECMD) delete -f batchgeocode.yaml
+
+reset-basic: stop-basic start-basic
+
+status:
+	$(KUBECMD) get pods --namespace batch-geocode
+
+get_ip:
+	$(KUBECMD) get services --namespace batch-geocode
+
+login:
+	$(KUBECMD) -n batch-geocode exec -it batchgeocode-0 -- /bin/bash

--- a/batchgeocode.yaml
+++ b/batchgeocode.yaml
@@ -2,26 +2,23 @@ apiVersion: v1
 kind: Service
 metadata:
     name: batchgeocode
-    namespace: batch-geocode
-    annotations:
-        # NOTE: needs to match metallb YAML config
-        metallb.universe.tf/address-pool: batch-geo
+    namespace: default
     labels:
         app: batchgeocode
 spec:
+    type: ClusterIP
     ports:
         - name: batchgeocode
-          port: 9000
+          port: 80
           protocol: TCP
           targetPort: 5000
     selector:
         app: batchgeocode
-    type: LoadBalancer
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-    namespace: batch-geocode
+    namespace: default
     name: batchgeocode
 spec:
     selector:
@@ -40,4 +37,23 @@ spec:
                 image: mlc314/batch_geocode
                 ports:
                   - name: batchgeocode
-                    containerPort: 9000
+                    containerPort: 80
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+    name: batchgeocode
+    namespace: default
+spec:
+    entryPoints:
+        - ssl
+    routes:
+    # NOTE: backticks - NOT QUOTES
+    - match: Host(`batch-geocode.sae.ihme.washington.edu`)
+      kind: Rule
+      services:
+      - name: batchgeocode
+        port: 80
+    tls:
+        store:
+            name: default

--- a/batchgeocode.yaml
+++ b/batchgeocode.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: batchgeocode
+    namespace: batch-geocode
+    annotations:
+        # NOTE: needs to match metallb YAML config
+        metallb.universe.tf/address-pool: batch-geo
+    labels:
+        app: batchgeocode
+spec:
+    ports:
+        - name: batchgeocode
+          port: 9000
+          protocol: TCP
+          targetPort: 5000
+    selector:
+        app: batchgeocode
+    type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+    namespace: batch-geocode
+    name: batchgeocode
+spec:
+    selector:
+        matchLabels:
+            app: batchgeocode
+    serviceName: batchgeocode
+    replicas: 1
+    template:
+        metadata:
+            labels:
+                app: batchgeocode
+        spec:
+            dnsPolicy: Default
+            containers:
+              - name: batchgeocode
+                image: mlc314/batch_geocode
+                ports:
+                  - name: batchgeocode
+                    containerPort: 9000


### PR DESCRIPTION
Upgrading python to 3.10 since 3.6 now has security concerns. Also updates some deployment details for IHME use only.